### PR TITLE
closing #8 Cleanup

### DIFF
--- a/aiocloudflare/cloudflare.py
+++ b/aiocloudflare/cloudflare.py
@@ -70,14 +70,13 @@ class Cloudflare:
                 API token from Cloudflare. Defaults to None.
             certtoken (Optional[str], optional):
                 To use Cert Token **current not implemented**. Defaults to None.
-            raw (Optional[str], optional): Not Implemented. Defaults to None.
+            user_agent (Optional[dict[str,str]], optional):
+                To modify the user agent header send to Cloudflare API. Most
+                for Cloudflare support when erro occurs.
             base_url (Optional[str], optional): If not provided, it will
                 defaults to cloudflare's v4 API. Defaults to None.
             debug (Optional[bool], optional): To set debug as true, logs will
                 be more verbose. Defaults to False.
-            test (Optional[bool], optional): If True, config will ignore all
-                args in the init method and use a seperate config must be
-                provided. Defaults to None.
             config (Optional[Config], optional): An optional config class
                 include all settings. Defaults to None.
         """

--- a/aiocloudflare/cloudflare.py
+++ b/aiocloudflare/cloudflare.py
@@ -39,12 +39,9 @@ class Cloudflare:
         email: Optional[str] = None,
         token: Optional[str] = None,
         certtoken: Optional[str] = None,
-        raw: Optional[str] = None,  # TODO
-        profile: Optional[str] = None,  # TODO
         user_agent: Optional[dict[str, str]] = None,
         base_url: Optional[str] = None,
         debug: Optional[bool] = False,
-        test: Optional[bool] = None,  # TODO
         logger: Optional[Logger] = None,
         config: Optional[Config] = None,
     ) -> None:
@@ -91,12 +88,9 @@ class Cloudflare:
                 email,
                 token,
                 certtoken,
-                raw,
-                profile,
                 user_agent,
                 base_url,
                 debug,
-                test,
             )
 
             if logger:

--- a/aiocloudflare/commons/config.py
+++ b/aiocloudflare/commons/config.py
@@ -32,38 +32,20 @@ class Config:
         email: Optional[str] = None,
         token: Optional[str] = None,
         certtoken: Optional[str] = None,
-        raw: Optional[str] = None,  # TODO
-        profile: Optional[str] = None,  # TODO
         user_agent: Optional[dict[str, str]] = None,
         base_url: Optional[str] = None,
         debug: Optional[bool] = False,
-        test: Optional[bool] = None,  # TODO
     ) -> None:
-        self.TEST: bool = self.__env_or_init(test, "TEST", False)
-        self.USER_AGENT: str = self.__env_or_init(
-            user_agent, "USER_AGENT", "aiocloudflare"
-        )
-        # skip initialising for tests
-        # hacky implementation, should use .env or .testenv for it
-        # TODO
-        if test:
-            self.EMAIL = None
-            self.TOKEN = None
-            self.CERTTOKEN = None
-            self.BASE_URL = None
-            self.DEBUG = False
-            return
-
         self.EMAIL = self.__env_or_init(email, "CF_API_EMAIL")
         self.TOKEN = self.__env_or_init(token, "CF_API_KEY")
         self.CERTTOKEN = self.__env_or_init(certtoken, "CF_API_CERTKEY")
+        self.USER_AGENT: str = self.__env_or_init(
+            user_agent, "USER_AGENT", "aiocloudflare"
+        )
         self.BASE_URL = self.__env_or_init(
             base_url, "CF_API_URL", "https://api.cloudflare.com/client/v4"
         )
         self.DEBUG = self.__env_or_init(debug, "DEBUG", False)
-
-        self.RAW = None
-        self.PROFILE = self.__env_or_init(profile, "CF_PROFILE")
 
     def __env_or_init(
         self, var: Any, env_key: str, default_value: Optional[Any] = None

--- a/noxfile.py
+++ b/noxfile.py
@@ -16,7 +16,7 @@ except ImportError:
 
 
 package = "aiocloudflare"
-python_versions = ["3.9", "3.8", "3.7"]
+python_versions = ["3.9"]
 nox.needs_version = ">= 2021.6.6"
 nox.options.sessions = ("pre-commit", "safety", "mypy", "tests")
 
@@ -113,7 +113,7 @@ def mypy(session: Session) -> None:
 def tests(session: Session) -> None:
     """Run the test suite."""
     session.install(".")
-    session.install("coverage[toml]", "pytest", "pygments", "respx")
+    session.install("coverage[toml]", "pytest", "pygments", "respx", "pytest-asyncio")
     try:
         session.run("coverage", "run", "--parallel", "-m", "pytest", *session.posargs)
     finally:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aiocloudflare"
-version = "0.2.0-bata"
+version = "0.2.0-beta"
 description = "A Cloudflare API wrapper for Python with asyncio support"
 authors = ["Stewart Wong <siwei.wong@gmail.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aiocloudflare"
-version = "0.1.3-alpha"
+version = "0.2.0-bata"
 description = "A Cloudflare API wrapper for Python with asyncio support"
 authors = ["Stewart Wong <siwei.wong@gmail.com>"]
 license = "MIT"
@@ -8,7 +8,7 @@ readme = "README.rst"
 homepage = "https://github.com/stewart86/aiocloudflare"
 repository = "https://github.com/stewart86/aiocloudflare"
 classifiers = [
-    "Development Status :: 2 - Pre-Alpha",
+    "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Programming Language :: Python :: 3.9",
     "Topic :: Software Development :: Libraries :: Python Modules",


### PR DESCRIPTION
- raw
    - main cloudflare python api handle response before sending to consumer, providing a raw flag allow non-processed data to be returned. We are not doing that for this api.. so raw is not needed.
- test
    - is was used for pre-alpha and not needed now.
- profile
    - main cloudflare uses profile only for `__repr__` and `__str__` not useful for now. 